### PR TITLE
Show the end hour in time-dependent tooltip

### DIFF
--- a/Source/Fluffy_Tabs/Work/PawnPrioritiesTracker.cs
+++ b/Source/Fluffy_Tabs/Work/PawnPrioritiesTracker.cs
@@ -291,7 +291,7 @@ namespace Fluffy_Tabs
                 // stop condition
                 if ( curpriority != priority && start >= 0 )
                 {
-                    tip += start.FormatHour() + " - " + 0.FormatHour();
+                    tip += start.FormatHour() + " - " + hour.FormatHour();
                     if ( Find.PlaySettings.useWorkPriorities )
                         tip += " (" + priority + ")";
                     tip += "\n";


### PR DESCRIPTION
The tooltip for scheduled work priorities in Dwarf Therapist mode always shows 00:00 as the end hour.  This change makes the tooltip show the hour when the prioritized work ends.

Before:
<img width="547" alt="end hour always 0" src="https://cloud.githubusercontent.com/assets/11951774/21667839/80aee008-d2b9-11e6-8182-1ab75c7b16a9.png">

After:
<img width="244" alt="end hour shows time priority ends" src="https://cloud.githubusercontent.com/assets/11951774/21667843/88bdb92c-d2b9-11e6-9d7f-db0bfed4f733.png">
