### PR TITLE
make scroll wheel usage optional

### DIFF
--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -26,6 +26,8 @@
     <WorkTab.PlayCrunch>Crunchy sounds</WorkTab.PlayCrunch>
     <WorkTab.PlayCrunchTip>Play a crunchy sound when a pawn is assigned to a job they are not skilled at?</WorkTab.PlayCrunchTip>
     
+    <WorkTab.DisableScrollwheel>Disable Scrollwheel</WorkTab.DisableScrollwheel>
+    <WorkTab.DisableScrollwheelTip>Disable the scrollwheel functions (when hovering over skills)</WorkTab.DisableScrollwheelTip>
     <!-- scheduler -->
     <WorkTab.SchedulerHourTip>{0}-{1} is currently {2}\n\n{3}</WorkTab.SchedulerHourTip>
     <WorkTab.Selected>selected</WorkTab.Selected>

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -13,6 +13,7 @@ namespace WorkTab
         public static bool playCrunch = true;
         public static bool playSounds = true;
         public static bool TwentyFourHourMode = true;
+        public static bool disableScrollwheel = false;
 
         // buffers
         private static string maxPriorityBuffer = maxPriority.ToString();
@@ -26,6 +27,7 @@ namespace WorkTab
             options.CheckboxLabeled("WorkTab.PlaySounds".Translate(), ref playSounds, "WorkTab.PlaySoundsTip".Translate());
             playCrunch = playSounds && playCrunch; // disabling sounds also disables crunch.
             options.CheckboxLabeled("WorkTab.PlayCrunch".Translate(), ref playCrunch, !playSounds, "WorkTab.PlayCrunchTip".Translate());
+            options.CheckboxLabeled("WorkTab.DisableScrollwheel".Translate(), ref disableScrollwheel, "WorkTab.DisableScrollwheelTip".Translate());
             options.End();
         }
 
@@ -37,6 +39,7 @@ namespace WorkTab
             Scribe_Values.Look(ref TwentyFourHourMode, "TwentyFourHourMode", true);
             Scribe_Values.Look(ref playSounds, "PlaySounds", true);
             Scribe_Values.Look(ref playCrunch, "PlayCrunch", true);
+            Scribe_Values.Look(ref disableScrollwheel, "DisableScrollwheel", false);
         }
 
         #endregion

--- a/Source/Utilities/InteractionUtilities.cs
+++ b/Source/Utilities/InteractionUtilities.cs
@@ -33,6 +33,9 @@ namespace WorkTab
 
         public static bool Scrolled( Rect rect, ScrollDirection direction, bool stopPropagation )
         {
+            if (Settings.disableScrollwheel)
+                return false;
+
             bool scrolled = Event.current.type == EventType.ScrollWheel &&
                    ( ( Event.current.delta.y > 0 && direction == ScrollDirection.Up ) ||
                      ( Event.current.delta.y < 0 && direction == ScrollDirection.Down ) ) &&


### PR DESCRIPTION
Adds a setting to the mod menu to optionally disable the usage of the mouse scroll wheel.

Some people have trouble with loose scroll wheels causing accidental changes to their priorities. 

This is not yet translated into any other language.
