### PR TITLE
compatibility with Numbers

### DIFF
--- a/Source/HarmonyPatches/PawnTable/PawnTable_PawnTableOnGUI.cs
+++ b/Source/HarmonyPatches/PawnTable/PawnTable_PawnTableOnGUI.cs
@@ -11,7 +11,7 @@ using Verse;
 
 namespace WorkTab
 {
-    [HarmonyPatch( typeof( PawnTable ), "PawnTableOnGUI" )]
+    [HarmonyPatch( typeof( PawnTable ), nameof ( PawnTable.PawnTableOnGUI ) ) ]
     public class PawnTable_PawnTableOnGUI
     {
         private static Type ptt = typeof( PawnTable );
@@ -30,8 +30,12 @@ namespace WorkTab
             if ( standardMarginField == null ) throw new NullReferenceException( "standardMargin field not found." );
         }
 
-        public static bool Prefix( PawnTable __instance, Vector2 position )
+        public static bool Prefix( PawnTable __instance, Vector2 position, PawnTableDef ___def)
+            //harmony 1.2.0.1 gives access to private fields by ___name.
         {
+            if (___def != PawnTableDefOf.Work) // best practices means we transpile. Nobody is that nuts, right?
+                return true;
+
             if (Event.current.type == EventType.Layout)
             {
                 return false;

--- a/Source/HarmonyPatches/PawnTable/PawnTable_RecacheIfDirty.cs
+++ b/Source/HarmonyPatches/PawnTable/PawnTable_RecacheIfDirty.cs
@@ -24,11 +24,11 @@ namespace WorkTab
             if (cachecColumnWidthsField == null) throw new NullReferenceException("PawnTable.cachecColumnWidths field not found.");
         }
 
-        private static void Prefix( PawnTable __instance, ref bool __state )
+        private static void Prefix( PawnTable __instance, ref bool __state, PawnTableDef ___def )
         {
-            __state = (bool)dirtyField.GetValue( __instance );
+            __state = (bool)dirtyField.GetValue( __instance ) && ___def == PawnTableDefOf.Work;
             if (__state)
-                Logger.Debug( "ColumnWidts dirty" );
+                Logger.Debug( "ColumnWidths dirty" );
         }
 
         private static void Postfix( PawnTable __instance, bool __state )

--- a/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
@@ -297,9 +297,9 @@ namespace WorkTab
             .Where( ShouldDrawCell )
             .ToList();
 
-        public void HeaderInteractions( Rect rect, PawnTable table )
+        public void HeaderInteractions( Rect headerRect, PawnTable table )
         {
-            if ( !Mouse.IsOver( rect ) )
+            if ( !Mouse.IsOver( headerRect ) )
                 return;
 
             // handle interactions
@@ -308,16 +308,16 @@ namespace WorkTab
                 // deal with clicks and scrolls
                 if ( Find.PlaySettings.useWorkPriorities )
                 {
-                    if ( ScrolledUp( rect, true ) || RightClicked( rect ) )
+                    if ( ScrolledUp( headerRect, true ) || RightClicked( headerRect ) )
                         WorkGiver.IncrementPriority( CapablePawns, VisibleHour, SelectedHours );
-                    if ( ScrolledDown( rect, true ) || LeftClicked( rect ) )
+                    if ( ScrolledDown( headerRect, true ) || LeftClicked( headerRect ) )
                         WorkGiver.DecrementPriority( CapablePawns, VisibleHour, SelectedHours );
                 }
                 else
                 {
                     // this gets slightly more complicated
                     var pawns = CapablePawns;
-                    if ( ScrolledUp( rect, true ) || RightClicked( rect ) )
+                    if ( ScrolledUp( headerRect, true ) || RightClicked( headerRect ) )
                     {
                         if ( pawns.Any( p => p.GetPriority( WorkGiver, VisibleHour ) != 0 ) )
                         {
@@ -328,7 +328,7 @@ namespace WorkTab
                         }
                     }
 
-                    if ( ScrolledDown( rect, true ) || LeftClicked( rect ) )
+                    if ( ScrolledDown( headerRect, true ) || LeftClicked( headerRect ) )
                     {
                         if ( pawns.Any( p => p.GetPriority( WorkGiver, VisibleHour ) == 0 ) )
                         {
@@ -342,9 +342,9 @@ namespace WorkTab
             }
             else if ( def.sortable )
             {
-                if ( LeftClicked( rect ) )
+                if ( LeftClicked( headerRect ) )
                     Sort( table );
-                if ( RightClicked( rect ) )
+                if ( RightClicked( headerRect ) )
                     Sort( table, false );
             }
         }

--- a/Source/PawnColumns/PawnColumnWorker_WorkType.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkType.cs
@@ -300,9 +300,9 @@ namespace WorkTab
             return result;
         }
 
-        public void HeaderInteractions( Rect rect, PawnTable table )
+        public void HeaderInteractions( Rect headerRect, PawnTable table )
         {
-            if ( !Mouse.IsOver( rect ) )
+            if ( !Mouse.IsOver( headerRect ) )
                 return;
 
             // handle interactions
@@ -311,16 +311,16 @@ namespace WorkTab
                 // deal with clicks and scrolls
                 if ( Find.PlaySettings.useWorkPriorities )
                 {
-                    if ( ScrolledUp( rect, true ) || RightClicked( rect ) )
+                    if ( ScrolledUp( headerRect, true ) || RightClicked( headerRect ) )
                         def.workType.IncrementPriority( CapablePawns, VisibleHour, SelectedHours );
-                    if ( ScrolledDown( rect, true ) || LeftClicked( rect ) )
+                    if ( ScrolledDown( headerRect, true ) || LeftClicked( headerRect ) )
                         def.workType.DecrementPriority( CapablePawns, VisibleHour, SelectedHours );
                 }
                 else
                 {
                     // this gets slightly more complicated
                     var pawns = CapablePawns;
-                    if ( ScrolledUp( rect, true ) || RightClicked( rect ) )
+                    if ( ScrolledUp( headerRect, true ) || RightClicked( headerRect ) )
                     {
                         if ( pawns.Any( p => p.GetPriority( def.workType, VisibleHour ) != 0 ) )
                         {
@@ -331,7 +331,7 @@ namespace WorkTab
                         }
                     }
 
-                    if ( ScrolledDown( rect, true ) || LeftClicked( rect ) )
+                    if ( ScrolledDown( headerRect, true ) || LeftClicked( headerRect ) )
                     {
                         if ( pawns.Any( p => p.GetPriority( def.workType, VisibleHour ) == 0 ) )
                         {
@@ -345,14 +345,14 @@ namespace WorkTab
             }
             else if ( Event.current.control )
             {
-                if ( CanExpand && Clicked( rect ) )
+                if ( CanExpand && Clicked( headerRect ) )
                     Expanded = !Expanded;
             }
             else if ( def.sortable )
             {
-                if ( LeftClicked( rect ) )
+                if ( LeftClicked( headerRect ) )
                     Sort( table );
-                if ( RightClicked( rect ) )
+                if ( RightClicked( headerRect ) )
                     Sort( table, false );
             }
         }


### PR DESCRIPTION
- Less destructive prefixes on the PawnTable
- Keeping the same argument names on HeaderInteractions as HeaderClicked, to make it easier for Numbers to patch the method.

I hope you'll agree the change to the PawnTable, it's a more defensive code practice that benefits us both.

You can take or leave the changes to the HeaderInteractions. I'll admit it's part laziness: I could also duplicate my own method to take your argument names instead. I use the interactive header functionality in my MainTable (and only my table) to remove columns on right-click.